### PR TITLE
Add dependency to useEffect to avoid infinite loop when fetching products

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "react-ecommerce",
       "version": "0.0.1",
       "dependencies": {
         "@headlessui/react": "^1.6.0",

--- a/src/Components/ProductTable.jsx
+++ b/src/Components/ProductTable.jsx
@@ -7,7 +7,12 @@ const getDefaultFilterOptions = () => {
       { minValue: 0, maxValue: 25, label: "$0 - $25", checked: false },
       { minValue: 25, maxValue: 50, label: "$25 - $50", checked: false },
       { minValue: 50, maxValue: 75, label: "$50 - $75", checked: false },
-      { minValue: 75, maxValue: Number.MAX_VALUE, label: "$75+", checked: false },
+      {
+        minValue: 75,
+        maxValue: Number.MAX_VALUE,
+        label: "$75+",
+        checked: false,
+      },
     ],
     color: [
       { value: "beige", label: "Beige", checked: false },
@@ -38,13 +43,15 @@ export default function ProductTable({ cart, updateCart }) {
     let res = await fetch("http://localhost:3001/products");
     let body = await res.json();
     setProducts(body);
-  });
+  }, []);
 
   return (
     <div className="bg-white">
       <div className="max-w-2xl mx-auto px-4 sm:px-6 lg:max-w-7xl lg:px-8">
         <h2 className="sr-only">Products</h2>
-        <ProductFilters {...{ filterOptions, setFilterOptions, sortOptions, setSortOptions }} />
+        <ProductFilters
+          {...{ filterOptions, setFilterOptions, sortOptions, setSortOptions }}
+        />
 
         <div className="grid grid-cols-1 gap-y-10 sm:grid-cols-2 gap-x-6 lg:grid-cols-3 xl:grid-cols-4 xl:gap-x-8">
           {products.map((product) => (
@@ -79,7 +86,9 @@ export default function ProductTable({ cart, updateCart }) {
                 </button>
               </div>
               <h3 className="mt-4 text-sm text-gray-700">{product.name}</h3>
-              <p className="mt-1 text-lg font-medium text-gray-900">${product.price}</p>
+              <p className="mt-1 text-lg font-medium text-gray-900">
+                ${product.price}
+              </p>
             </a>
           ))}
         </div>


### PR DESCRIPTION
1. It's possible my linter might've reformatted the code a bit. Is there a local linter file that we can add to the repository?

2. I added an empty dependency when fetching the products. Not entirely sure if this is best practice, but we only want it to render onload so it made sense to me.
