### PR TITLE
Update cart items to pass the test for Issue #2

### DIFF
--- a/src/Components/Cart.jsx
+++ b/src/Components/Cart.jsx
@@ -56,7 +56,7 @@ export default function Cart({ open, setOpen, cart, updateCart }) {
                       <div className="flow-root">
                         <ul role="list" className="-my-6 divide-y divide-gray-200">
                           {cart.map((product) => (
-                            <li key={product.id} className="flex py-6">
+                            <li role="listitem" key={product.id} className="flex py-6">
                               <div className="h-24 w-24 flex-shrink-0 overflow-hidden rounded-md border border-gray-200">
                                 <img
                                   src={product.imageSrc}


### PR DESCRIPTION
What:
- Adds the `listitem` role to rendered cart items in `Cart.jsx`.

Why:
- Assuming Issue #2 has been properly fixed in the project, the added role will help the modified project pass the test that checks if Issue #2 has been fixed.
- If this role is not added to the shopping cart list item, the test in the test repository for this project that checks if Issue #2 has been fixed will fail.
- That test specifically counts the number of (shopping cart) elements with a `role` attribute of `listitem`. 
- Since the items in the shopping cart do not have that role, the test will fail even if the issue (Issue #2) has been fixed.

References:
- [The test repository for this project](https://github.com/developer-job-simulation/react-ecommerce-tests/blob/main/test.js)